### PR TITLE
Add VS/vcpkg CMake preset and add README.md for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0100 NEW)  # handle .hh files
-if (WIN32)
-    set(CMAKE_TOOLCHAIN_FILE "./vcpkg/scripts/buildsystems/vcpkg.cmake")
-endif()
-
 project(CLAP_PLUGINS C CXX)
 
 add_subdirectory(clap)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0100 NEW)  # handle .hh files
+if (WIN32)
+    set(CMAKE_TOOLCHAIN_FILE "./vcpkg/scripts/buildsystems/vcpkg.cmake")
+endif()
+
 project(CLAP_PLUGINS C CXX)
 
 add_subdirectory(clap)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,6 +24,19 @@
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
         }
       }
+    },
+    {
+      "name": "vs-vcpkg",
+      "displayName": "Visual Studio + VCPKG",
+      "description": "Configure with vcpkg toolchain and generate VS project files for all configurations",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Visual Studio 16 2019",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
     }
   ],
   "buildPresets": [

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Clap Plugin Examples
+
+This repo contains some example CLAP plugins.
+
+## Building on various platforms
+
+### Windows
+
+WARNING: Make sure that you've cloned this repository into a short path to avoid running into the 255 character path limit later on. The repository's default name `clap-plugins` placed into the root of a drive would already be too long! Clone or rename it to something like `C:\clappl` or `D:\clappl`.  
+
+In case you haven't already, install the necessary tools:
+```powershell
+choco install cmake -y
+```
+
+Dependencies on Windows are managed by vcpkg through CMake. For that to work, you'll have to init and checkout all submodules, which includes vcpkg:
+```powershell
+git submodule init
+git submodule update
+```
+
+You can now open the project with CMake and configure & generate the solutions. CMake should be able to automatically detect vcpkg, bootstrap and acquire the necessary packages. This will take some time because `qtdeclarative` will be downloaded and built from source on your machine. However, this is necessary only once after cloning.  

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ git submodule init
 git submodule update
 ```
 
-You can now open the project with CMake and configure & generate the solutions. CMake should be able to automatically detect vcpkg, bootstrap and acquire the necessary packages. This will take some time because `qtdeclarative` will be downloaded and built from source on your machine. However, this is necessary only once after cloning.  
+You can now open the project with CMake, select the `Visual Studio + VCPKG` preset and configure & generate the solutions (tested with VS 2019). CMake should be able to automatically detect vcpkg, bootstrap and acquire the necessary packages. This will take some time because `qtdeclarative` will be downloaded and built from source on your machine. However, this is necessary only once after cloning.  


### PR DESCRIPTION
This PR improves Windows support by adding a CMake preset for VS with vcpkg. It also includes a README.md with instructions on how to configure and generate a solution for VS 2019.  

There's still an issue somewhere with the includes, included paths or the code that's causing the included compiler tests and the plugin project to fail during compilation, but that's not the scope of this PR.