### PR TITLE
index check in Parameters::getByIndex looks wrong

### DIFF
--- a/plugins/parameters.cc
+++ b/plugins/parameters.cc
@@ -19,7 +19,7 @@ namespace clap {
    size_t Parameters::count() const noexcept { return _params.size(); }
 
    Parameter *Parameters::getByIndex(size_t index) const noexcept {
-      if (index > _params.size())
+      if (index >= _params.size())
          return nullptr;
       return _params[index].get();
    }


### PR DESCRIPTION
This just looks suspicious. Have not tested it but just discovered by reading through the file.