### PR TITLE
Add more Mac homebrew dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cmake --build --preset ninja-system
 
 ```shell
 # Install build tools
-brew install cmake ninja
+brew install cmake ninja autoconf automake
 
 # Checkout the code
 git clone --recurse-submodules https://github.com/free-audio/clap-plugins


### PR DESCRIPTION
Following the "macOS with vcpkg" build instructions on my system (Mac OS 13.2.1, Intel cpu), I got a couple build failures, which were resolved by installing `autoconf` and `automake` via homebrew. This adds those dependencies to the appropriate command in the readme.