### PR TITLE
Use "utf-8" compile flag to support MSVC build process in multi-byte character environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "AppleClang|Clang")
   add_compile_options(-Wmost -Wsuper-class-method-mismatch)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  add_compile_options(/utf-8)
+endif()
+
 add_subdirectory(clap EXCLUDE_FROM_ALL)
 add_subdirectory(clap-helpers EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
Hello, I found to fixes to compile robustly in Windows, MSVC in various language environments..

## What happened.

I have encountered compilation failures in Japanese Windows and MSVC environments.
The compile error message is as follows
```
$ ./scripts/build-headless.sh 
Preset CMake variables:

  CLAP_PLUGINS_HEADLESS:BOOL="TRUE"
  CMAKE_EXPORT_COMPILE_COMMANDS:BOOL="TRUE"

-- Selecting Windows SDK version 10.0.22000.0 to target Windows 10.0.22621.
-- CLAP version: 1.1.8
-- Configuring done
CMake Warning (dev) in plugins/CMakeLists.txt:
  AUTOGEN: No valid Qt version found for target clap-plugins.  AUTOMOC
  disabled.  Consider adding:

    find_package(Qt<QTVERSION> COMPONENTS Core)

  to your CMakeLists.txt file.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: C:/Users/(my-system-secret)/free-audio/clap-plugins/builds/vs-headless
MSBuild version 17.6.3+07e294721 for .NET Framework

  Checking Build System
  Building Custom Rule C:/Users/(my-system-secret)/free-audio/clap-plugins/plugins/CMakeLists.txt
  audio-buffer.cc
  clap-entry.cc
  core-plugin.cc
  merge-process-status.cc
  adsr-module.cc
  module.cc
  root-module.cc
  voice-expander-module.cc
  voice-module.cc
  svf-module.cc
  digi-osc-module.cc
  parameter.cc
  parameters.cc
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.36.32532\include\memory(3465,56): warning C4267: '引数': 'size_t' から 'uint32_t' に変換しました。データが失われているかもしれません。 [C:\Users\
(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\parameters.cc(10,21): message : コンパイル対象の関数 テンプレート インスタンス化 'std::unique_ptr<clap::Parameter,std::default_delete<clap::Paramet
er>> std::make_unique<clap::Parameter,const clap_param_info&,std::unique_ptr<clap::ValueType,std::default_delete<clap::ValueType>>,unsigned __int64,0>(const clap_param_info &,std::unique_ptr< 
clap::ValueType,std::default_delete<clap::ValueType>> &&,unsigned __int64 &&)' のリファレンスを確認してください [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plu
gins.vcxproj]
  path-provider.cc
  adsr-plug.cc
  char-check.cc
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(1,1): warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。
データの損失を防ぐために、ファイルを Unicode 形式で保存
してください。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(45,20): error C2001: 定数が 2 行目に続いています。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(46,7): error C2146: 構文エラー: ')' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(46,7): error C2146: 構文エラー: ';' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(47,20): error C2001: 定数が 2 行目に続いています。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(48,7): error C2146: 構文エラー: ')' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(48,7): error C2146: 構文エラー: ';' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(48,20): error C2001: 定数が 2 行目に続いています。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(49,7): error C2146: 構文エラー: ')' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(49,7): error C2146: 構文エラー: ';' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(49,20): error C2001: 定数が 2 行目に続いています。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(50,7): error C2146: 構文エラー: ')' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(50,7): error C2146: 構文エラー: ';' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(50,20): error C2001: 定数が 2 行目に続いています。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(51,7): error C2146: 構文エラー: ')' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(51,7): error C2146: 構文エラー: ';' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(54,20): error C2001: 定数が 2 行目に続いています。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(55,7): error C2146: 構文エラー: ')' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
C:\Users\(my-system-secret)\free-audio\clap-plugins\plugins\plugs\char-check\char-check.cc(55,7): error C2146: 構文エラー: ';' が、識別子 'addDumbParam' の前に必要です。 [C:\Users\(my-system-secret)\free-audio\clap-plugins\builds\vs-headless\plugins\clap-plugins.vcxproj]
  dc-offset.cc
  gain.cc
  latency.cc
  offline-latency.cc
  コードを生成中...
  コンパイル中...
  realtime-requirement.cc
  synth.cc
  transport-info.cc
  svf-plug.cc
  sample-delay.cc
  stream-helper.cc
  tuning-provider.cc
  decibel-value-type.cc
  simple-value-type.cc
  value-type.cc
  frequency-value-type.cc
  enumerated-value-type.cc
  コードを生成中...
```

Specifically, the compiler fails to interpret the multibyte string impled in `plugins/plugs/char-check/char-check.cc` as UTF-8.

```
   CharCheck::CharCheck(const std::string &pluginPath, const clap_host *host)
      : CorePlugin(PathProvider::create(pluginPath, "char-check"), descriptor(), host) {
      _rootModule = std::make_unique<CharCheckModule>(*this);

      addDumbParam("Hello");
      addDumbParam("こんにちは");
      addDumbParam("テレビ");
      addDumbParam("富士山");
      addDumbParam("שלום");
      addDumbParam("नमस्ते");
      addDumbParam("Привет");
      addDumbParam("سلام");
      addDumbParam("ਸਤ ਸ੍ਰੀ ਅਕਾਲ");
      addDumbParam("أهلا");
      addDumbParam("你好");
      addDumbParam("안녕하세요");
      addDumbParam("Pẹlẹ o");
      addDumbParam("Χαίρετε");
      addDumbParam("Hot Pepper" PEPPER, "/" PEPPER);
   }
```

## How to solve.

The official MSVC documentation notes that by adding utf-8 to the compiler flags, it is possible to explicitly have multibyte strings in source code interpreted as UTF-8.
https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170

Note that my change of `if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")` is different from `if(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")` as your cmake code.
The reason for above is based on the following post on StackOverflow.
https://stackoverflow.com/questions/41692725/cmake-doesnt-recognize-msvc-compiler