### PR TITLE
Fix for compile error for MSVC due to GCC extension.

### DIFF
--- a/plugins/core-plugin.cc
+++ b/plugins/core-plugin.cc
@@ -860,7 +860,7 @@ namespace clap {
 #ifndef CLAP_PLUGINS_HEADLESS
       if (_guiHandle)
          _guiHandle->gui().setParameterMappingIndication(
-            param_id, has_mapping, c, label ?: "", description ?: "");
+            param_id, has_mapping, c, label ? label : "", description ? description : "");
 #endif
    }
 


### PR DESCRIPTION
I found source code that does not compile with MSVC. Please check the change difference.

This issue is due to the following circumstances.

Conditionals with Omitted Operands syntax `label ?: ""` is a GNU extension. It's not supported in MSVC (even in the latest version). 
Reference: https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html

The following source code can be used to verify that the compiler behaves differently.
```
// Type your code here, or load an example.
#include <iostream>
#include <cstdlib>

int main()
{
    const char* buffer = "This is a text.";
#if 1
    const std::string text = buffer ?: std::string("");
#else
    const std::string text = buffer ? std::string(buffer) : std::string("");
#endif
    std::cout << text << std::endl;
}
```

Demo by godbolt: compile by clang with `-Wpedantic` compile option. Compiler outputs warning message.
Link: https://godbolt.org/z/zqv8YqzT4

Demo by godbolt: cmpile by msvc. Compile is failure.
Link: https://godbolt.org/z/MGEbWh8a3
